### PR TITLE
Fixed recursive calls when the ESP register is being re-used.

### DIFF
--- a/src/hook.h
+++ b/src/hook.h
@@ -158,6 +158,9 @@ private:
 	void* __cdecl GetReturnAddress(void* pESP);
 	void __cdecl SetReturnAddress(void* pRetAddr, void* pESP);
 
+	void* __cdecl CHook::PopReturnAddress(void* pESP);
+	void __cdecl CHook::SaveReturnAddress(void* pRetAddr, void* pESP);
+
 public:
 	std::map<HookType_t, std::list<HookHandlerFn*> > m_hookHandler;
 
@@ -178,7 +181,7 @@ public:
 	// New return address
 	void* m_pNewRetAddr;
 
-	std::map<void*, void*> m_RetAddr;
+	std::map<void*, std::vector<void*> > m_RetAddr;
 };
 
 #endif // _HOOK_H

--- a/src/hook.h
+++ b/src/hook.h
@@ -158,9 +158,6 @@ private:
 	void* __cdecl GetReturnAddress(void* pESP);
 	void __cdecl SetReturnAddress(void* pRetAddr, void* pESP);
 
-	void* __cdecl CHook::PopReturnAddress(void* pESP);
-	void __cdecl CHook::SaveReturnAddress(void* pRetAddr, void* pESP);
-
 public:
 	std::map<HookType_t, std::list<HookHandlerFn*> > m_hookHandler;
 


### PR DESCRIPTION
Originally reported there: https://forums.sourcepython.com/viewtopic.php?p=13855#p13855

The issue appears to only affect void functions, which I believe is the result of an optimization where the compiler assume it can safely re-use that register as it won't be using it anyways. This PR workaround this issue by saving then popping the return addresses in order, ensuring the post handler always work with the latest, etc.